### PR TITLE
feat: provide google oauth with effect redirects

### DIFF
--- a/next.config.js
+++ b/next.config.js
@@ -2,6 +2,15 @@
 const nextConfig = {
   reactStrictMode: true,
   swcMinify: true,
+  async redirects() {
+    return [
+      {
+        source: '/u',
+        destination: '/u/dashboard',
+        permanent: true,
+      },
+    ]
+  },
 }
 
 module.exports = nextConfig

--- a/pages/_app.tsx
+++ b/pages/_app.tsx
@@ -1,11 +1,33 @@
+import * as React from 'react'
+import { useRouter } from 'next/router'
+import { GeistProvider, CssBaseline } from '@geist-ui/core'
 import { UserProvider } from '@supabase/auth-helpers-react'
 import { supabaseClient } from '@supabase/auth-helpers-nextjs'
-import { GeistProvider, CssBaseline } from '@geist-ui/core'
 import 'tailwindcss/tailwind.css'
 import 'inter-ui/inter.css'
 import type { AppProps } from 'next/app'
 
 function MyApp({ Component, pageProps }: AppProps) {
+  const router = useRouter()
+
+  React.useEffect(() => {
+    const { data: authListener } = supabaseClient.auth.onAuthStateChange(async (event, session) => {
+      await fetch('/api/auth/callback', {
+        method: 'POST',
+        headers: new Headers({ 'Content-Type': 'application/json' }),
+        credentials: 'same-origin',
+        body: JSON.stringify({ event, session }),
+      })
+      if (event === 'SIGNED_IN') {
+        router.push('/u/dashboard')
+      } else if (event === 'SIGNED_OUT') {
+        router.push('/')
+      }
+    })
+    return () => authListener?.unsubscribe()
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [])
+
   return (
     <>
       <GeistProvider>

--- a/pages/index.tsx
+++ b/pages/index.tsx
@@ -1,6 +1,5 @@
 import * as React from 'react'
 import NextLink from 'next/link'
-import { useRouter } from 'next/router'
 import { Text, Input, Button, Divider, Link, useToasts } from '@geist-ui/core'
 import { getUser, supabaseClient } from '@supabase/auth-helpers-nextjs'
 import { useForm, SubmitHandler } from 'react-hook-form'
@@ -11,7 +10,6 @@ const LogIn: NextPage = () => {
   const [loading, setLoading] = React.useState<boolean>(false)
   const { register, handleSubmit, formState } = useForm<LogInTypes>()
   const { setToast } = useToasts()
-  const router = useRouter()
 
   const onSubmit: SubmitHandler<LogInTypes> = async ({ email, password }) => {
     setLoading(true)
@@ -20,7 +18,11 @@ const LogIn: NextPage = () => {
       setToast({ text: error.message, type: 'error' })
       return setLoading(false)
     }
-    router.push('/u/dashboard')
+  }
+
+  const withAuthProvider = async () => {
+    const { error } = await supabaseClient.auth.signIn({ provider: 'google' })
+    if (error) return setToast({ text: error.message, type: 'error' })
   }
 
   return (
@@ -65,7 +67,7 @@ const LogIn: NextPage = () => {
               OR
             </Text>
           </Divider>
-          <Button shadow type="secondary">
+          <Button shadow type="secondary" onClick={withAuthProvider}>
             Log In With Google
           </Button>
         </form>

--- a/pages/register.tsx
+++ b/pages/register.tsx
@@ -1,6 +1,5 @@
 import * as React from 'react'
 import NextLink from 'next/link'
-import { useRouter } from 'next/router'
 import { Text, Input, Button, Divider, Link, Fieldset, Code, useToasts } from '@geist-ui/core'
 import { getUser, supabaseClient } from '@supabase/auth-helpers-nextjs'
 import { useForm, SubmitHandler } from 'react-hook-form'
@@ -12,7 +11,6 @@ const Register: NextPage = () => {
   const [verifyEmail, setVerifyEmail] = React.useState<false | string>(false)
   const { register, handleSubmit, formState, setError, clearErrors } = useForm<SignUpTypes>()
   const { setToast } = useToasts()
-  const router = useRouter()
 
   const onSubmit: SubmitHandler<SignUpTypes> = async ({ email, password, confirm }) => {
     if (password !== confirm)
@@ -29,6 +27,11 @@ const Register: NextPage = () => {
       return setLoading(false)
     }
     setVerifyEmail(email)
+  }
+
+  const withAuthProvider = async () => {
+    const { error } = await supabaseClient.auth.signIn({ provider: 'google' })
+    if (error) return setToast({ text: error.message, type: 'error' })
   }
 
   return (
@@ -63,7 +66,10 @@ const Register: NextPage = () => {
             </Fieldset.Footer>
           </Fieldset>
         ) : (
-          <form onSubmit={handleSubmit(onSubmit)} className="mb-10 grid w-72 gap-3">
+          <form
+            onSubmit={handleSubmit(onSubmit)}
+            className="mb-10 grid w-72 gap-3 sm:w-screen sm:pr-24"
+          >
             <Text h4>Create your account</Text>
             <Input
               htmlType="email"
@@ -106,7 +112,7 @@ const Register: NextPage = () => {
                 OR
               </Text>
             </Divider>
-            <Button shadow type="secondary">
+            <Button shadow type="secondary" onClick={withAuthProvider}>
               Sign Up With Google
             </Button>
           </form>


### PR DESCRIPTION
**Description**

- Redirect automatically to `/u/dashboard` from `/u` without caching path.
- Add `useEffect` to redirect to pages instead of individual router calls.
- Set up Google OAuth for third-party authentication.